### PR TITLE
Drop deprecated set-output commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,8 +38,8 @@ if [ "${INPUT_TAG_CUSTOM}" != "" ]; then
   docker push "${INPUT_TARGET_IMAGE_NAME}:${INPUT_TAG_CUSTOM}"
 fi
 
-echo "::set-output name=image_tag::${TAG}"
-echo "::set-output name=image_tag_major::${DOCKER_IMAGE_TAG_MAJOR}"
-echo "::set-output name=image_tag_minor::${DOCKER_IMAGE_TAG_MINOR}"
-echo "::set-output name=image_tag_patch::${DOCKER_IMAGE_TAG_PATCH}"
-echo "::set-output name=image_tag_patch_with_pre_release::${DOCKER_IMAGE_TAG_PATCH_WITH_PRE_RELEASE}"
+echo "image_tag=${TAG}" >> $GITHUB_OUTPUT
+echo "image_tag_major=${DOCKER_IMAGE_TAG_MAJOR}" >> $GITHUB_OUTPUT
+echo "image_tag_minor={DOCKER_IMAGE_TAG_MINOR}" >> $GITHUB_OUTPUT
+echo "image_tag_patch={DOCKER_IMAGE_TAG_PATCH}" >> $GITHUB_OUTPUT
+echo "image_tag_patch_with_pre_release={DOCKER_IMAGE_TAG_PATCH_WITH_PRE_RELEASE}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The `::set-output` command is deprecated, see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for details.